### PR TITLE
Fix colors on html5 target

### DIFF
--- a/src/flash/display3D/textures/Texture.hx
+++ b/src/flash/display3D/textures/Texture.hx
@@ -45,8 +45,11 @@ class Texture extends TextureBase
 
 
 	public function uploadFromBitmapData (bitmapData:BitmapData, miplevel:Int = 0):Void {
-
+        #if html5
+        var p = bitmapData.getPixels(new flash.geom.Rectangle(0, 0, bitmapData.width, bitmapData.height));
+        #else
         var p = bitmapData.getRGBAPixels();
+        #end
         uploadFromByteArray(p, 0, miplevel);
 
 	}


### PR DESCRIPTION
This is needed because of the result of https://github.com/openfl/openfl-html5/blob/master/flash/display/BitmapData.hx#L821-L844. Not sure if there's a better way to do this by defining a different format somewhere else.
